### PR TITLE
Fixes Elixir 1.4 compiler warnings

### DIFF
--- a/lib/mollie/http.ex
+++ b/lib/mollie/http.ex
@@ -57,10 +57,10 @@ defmodule Mollie.Http do
   defp encode_request_body(l) when is_list(l), do: {:form, l}
 
   defp process_request_headers(headers) when is_map(headers) do
-    Enum.into(headers, [authorization_header])
+    Enum.into(headers, [authorization_header()])
   end
   defp process_request_headers(_headers) do
-    Enum.into(%{}, [authorization_header])
+    Enum.into(%{}, [authorization_header()])
   end
 
   @spec authorization_header() :: {:Authorization, binary}

--- a/mix.lock
+++ b/mix.lock
@@ -6,9 +6,9 @@
   "hackney": {:hex, :hackney, "1.6.1", "ddd22d42db2b50e6a155439c8811b8f6df61a4395de10509714ad2751c6da817", [:rebar3], [{:certifi, "0.4.0", [hex: :certifi, optional: false]}, {:idna, "1.2.0", [hex: :idna, optional: false]}, {:metrics, "1.0.1", [hex: :metrics, optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, optional: false]}, {:ssl_verify_fun, "1.1.0", [hex: :ssl_verify_fun, optional: false]}]},
   "idna": {:hex, :idna, "1.2.0", "ac62ee99da068f43c50dc69acf700e03a62a348360126260e87f2b54eced86b2", [:rebar3], []},
   "jsx": {:hex, :jsx, "2.6.2", "213721e058da0587a4bce3cc8a00ff6684ced229c8f9223245c6ff2c88fbaa5a", [:mix, :rebar], []},
-  "meck": {:hex, :meck, "0.8.4", "59ca1cd971372aa223138efcf9b29475bde299e1953046a0c727184790ab1520", [:rebar, :make], []},
+  "meck": {:hex, :meck, "0.8.4", "59ca1cd971372aa223138efcf9b29475bde299e1953046a0c727184790ab1520", [:make, :rebar], []},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], []},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], []},
   "mix_test_watch": {:hex, :mix_test_watch, "0.2.6", "9fcc2b1b89d1594c4a8300959c19d50da2f0ff13642c8f681692a6e507f92cab", [:mix], [{:fs, "~> 0.9.1", [hex: :fs, optional: false]}]},
   "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], []},
-  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0", "edee20847c42e379bf91261db474ffbe373f8acb56e9079acb6038d4e0bf414f", [:rebar, :make], []}}
+  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0", "edee20847c42e379bf91261db474ffbe373f8acb56e9079acb6038d4e0bf414f", [:make, :rebar], []}}


### PR DESCRIPTION
Since version 1.4, the Elixir compiler warns of missing parentheses in function calls. Calling `my_function/0` should be done with `my_function()` instead of `my_function`:

```
warning: variable "authorization_header" does not exist and is being expanded to "authorization_header()", please use parentheses to remove the ambiguity or change the variable name
  lib/mollie/http.ex:60

warning: variable "authorization_header" does not exist and is being expanded to "authorization_header()", please use parentheses to remove the ambiguity or change the variable name
  lib/mollie/http.ex:63
```

This PR fixes those warnings for Elixir 1.4.